### PR TITLE
security hardening bug - stack clash attacks

### DIFF
--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -220,7 +220,11 @@ public:
       for (uint32_t i = 0; i < vector.size(); i++) {
         vector[i] = C(rb_ary_entry(argv, i));
       }
-      return &vector[0];
+      if(vector.size() > 0){
+        return &vector[0];
+      } else {
+        return null;
+      }
     }
   private:
     VALUE argv;

--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -223,7 +223,7 @@ public:
       if(vector.size() > 0){
         return &vector[0];
       } else {
-        return null;
+        return NULL;
       }
     }
   private:


### PR DESCRIPTION
This is a priority bug: The C++ standard library hardening may detect some invalid out-of-bounds access which have gone unnoticed before.

Compile all binaries with stack clash protection (-fstack-clash-protection). As a result, attempts to jump the stack guard (a requirement for stack clash attacks) will reliably result in a crash rather than giving the attacker control over stack/heap objects.

check link for more details:
https://stackoverflow.com/questions/51661931/rails-s-command-issue/51662528#51662528

so now that the libstdc++ 8.1 is checking with assertions ON. Making this lib compatible with version >8.1 libstdc++